### PR TITLE
Make minikube start cmd editable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,11 @@
 ---
 # defaults file for minikube
 
-minikube_version: 1.11.0-0
+minikube_version: 1.20.0-0
 
 # `minikube start` should start as a non-root-user. This should be an exising
 # user on the Linux system. (Hint: robertdebock.users)
 minikube_user: minikube
+
+minikube_command: /usr/bin/minikube start --driver=none
+# minikube_command: /usr/bin/minikube start --vm-driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost --extra-config=kubelet.cgroup-driver=systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,5 +31,7 @@
   ansible.builtin.command:
     cmd: "{{ minikube_command }}"
     creates: nothing
+  become: true
+  become_user: "{{ minikube_user }}"
   when:
     - ansible_connection != "docker"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -28,6 +28,3 @@ _minikube_packages:
     - "https://storage.googleapis.com/minikube/releases/latest/minikube-{{ minikube_version }}.x86_64.rpm"
 
 minikube_packages: "{{ _minikube_packages[ansible_os_family] }}"
-
-minikube_command: /usr/bin/minikube start --vm-driver=none
-# minikube_command: /usr/bin/minikube start --vm-driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost --extra-config=kubelet.cgroup-driver=systemd


### PR DESCRIPTION
---
name: Edit minikube start command block
about: Make the minikube start command editable and run it as minikube_user

---
* Currently the minikube start command is set via `var/main.yml`. To make it editable it is now in `defaults/main.yml` allowing the use of different drivers and parameters.
* With setting the `become_user: {{ minikue_user }}` the command is executed as that user.
* Bump default version

 

